### PR TITLE
use 'path' for temporary PATH_TO_CENSUS

### DIFF
--- a/R/set_path_to_census.R
+++ b/R/set_path_to_census.R
@@ -67,6 +67,6 @@ set_path_to_census <- function (path){
         setwd(initial_wd)
 
     } else if (choice == "temporary"){
-        Sys.setenv(PATH_TO_CENSUS = tempdir())
+        Sys.setenv(PATH_TO_CENSUS = path)
     }
 }


### PR DESCRIPTION
Currently a directory in `/tmp` is being used when choosing option 1 for `set_path_to_census`
It seems like using the path specified is the intended behavior.